### PR TITLE
Add support for ppc64le platform

### DIFF
--- a/lib/chef/sugar/architecture.rb
+++ b/lib/chef/sugar/architecture.rb
@@ -25,7 +25,7 @@ class Chef
       # @return [Boolean]
       #
       def _64_bit?(node)
-        %w(amd64 x86_64 ppc64 s390x ia64 sparc64 aarch64 arch64 arm64)
+        %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64)
           .include?(node['kernel']['machine'])
       end
 

--- a/spec/unit/chef/sugar/architecture_spec.rb
+++ b/spec/unit/chef/sugar/architecture_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Chef::Sugar::Architecture do
   it_behaves_like 'a chef sugar'
 
-  _64_bit_machines = %w(amd64 x86_64 ppc64 s390x ia64 sparc64 aarch64 arch64 arm64)
+  _64_bit_machines = %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64)
 
   describe '#_64_bit?' do
     _64_bit_machines.each do |arch|


### PR DESCRIPTION
Add support for ppc64le platform. (required for RHEL7 powerpc little endian chef-client builds)