### PR TITLE
namespace precedence setting leaking between attribute blocks/files

### DIFF
--- a/lib/chef/sugar/node.rb
+++ b/lib/chef/sugar/node.rb
@@ -141,6 +141,9 @@ EOH
       instance_eval(&block)
       @current_namespace = current_namespace - keys
 
+      if @current_namespace.empty?
+        @namespace_options = nil
+      end
       nil
     end
 

--- a/spec/unit/chef/sugar/node_spec.rb
+++ b/spec/unit/chef/sugar/node_spec.rb
@@ -106,6 +106,48 @@ describe Chef::Node do
       })
     end
 
+    it 'maintains precedence level into nested calls' do
+      node.instance_eval do
+        namespace 'apache2', precedence: override do
+          namespace 'config' do
+            root '/var/www'
+          end
+        end
+      end
+
+      expect(node.override).to eq({
+        'apache2' => {
+          'config' => { 'root' => '/var/www' }
+        }
+      })
+    end
+
+    it 'resets precedence to default in subsequent non-nested calls' do
+      node.instance_eval do
+        namespace 'apache2', precedence: override do
+          namespace 'config' do
+            root '/var/www'
+          end
+        end
+
+        namespace 'php' do
+          version '5.3'
+        end
+      end
+
+      expect(node.override).to eq({
+        'apache2' => {
+          'config' => { 'root' => '/var/www' }
+        }
+      })
+
+      expect(node.default).to eq({
+        'php' => {
+          'version' => '5.3'
+        }
+      })
+    end
+
     it 'can access attributes within itself' do
       node.instance_eval do
         namespace 'apache2' do


### PR DESCRIPTION
I am still gathering evidence, but it appears that at least under chef 12.1.1, adding a `precedence: override` to a `namespace` block caused attributes in a different cookbook (also using chef-sugar) to start populating to `override` precedence things that were previously `default` (masking out some normal precedence values and breaking stuff in the process :( ) 