### PR TITLE
Updated SPARC logic and 32/64bit logic for x86 and i386

### DIFF
--- a/lib/chef/sugar/architecture.rb
+++ b/lib/chef/sugar/architecture.rb
@@ -55,7 +55,7 @@ class Chef
       # @return [Boolean]
       #
       def intel?(node)
-        %w(i86pc i386)
+        %w(i86pc i386 x86_64 amd64 i686)
           .include?(node['kernel']['machine'])
       end
 

--- a/lib/chef/sugar/architecture.rb
+++ b/lib/chef/sugar/architecture.rb
@@ -25,7 +25,7 @@ class Chef
       # @return [Boolean]
       #
       def _64_bit?(node)
-        %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64)
+        %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64 sun4v sun4u)
           .include?(node['kernel']['machine'])
       end
 
@@ -39,7 +39,15 @@ class Chef
       def _32_bit?(node)
         !_64_bit?(node)
       end
-      alias_method :i386?, :_32_bit?
+
+      #
+      # Determine if the current architecture is i386
+      #
+      # @return [Boolean]
+      #
+      def i386?(node)
+        _32_bit?(node) && intel?(node)
+      end
 
       #
       # Determine if the current architecture is Intel.
@@ -47,7 +55,7 @@ class Chef
       # @return [Boolean]
       #
       def intel?(node)
-        %w(i86pc)
+        %w(i86pc i386)
           .include?(node['kernel']['machine'])
       end
 

--- a/spec/unit/chef/sugar/architecture_spec.rb
+++ b/spec/unit/chef/sugar/architecture_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Chef::Sugar::Architecture do
   it_behaves_like 'a chef sugar'
 
-  _64_bit_machines = %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64)
+  _64_bit_machines = %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64 sun4u sun4v)
 
   describe '#_64_bit?' do
     _64_bit_machines.each do |arch|
@@ -33,9 +33,28 @@ describe Chef::Sugar::Architecture do
     end
   end
 
+  describe '#i386?' do
+    it 'returns true when the system is 32 bit' do
+      node = { 'kernel' => { 'machine' => 'i386' } }
+      expect(described_class.i386?(node)).to be true
+    end
+
+    _64_bit_machines.each do |arch|
+      it "returns false when the system is #{arch}" do
+        node = { 'kernel' => { 'machine' => arch } }
+        expect(described_class.i386?(node)).to be false
+      end
+    end
+  end
+
   describe '#intel?' do
     it 'returns true when the system is Intel' do
       node = { 'kernel' => { 'machine' => 'i86pc' } }
+      expect(described_class.intel?(node)).to be true
+    end
+
+    it 'returns true when the system is Intel' do
+      node = { 'kernel' => { 'machine' => 'i386' } }
       expect(described_class.intel?(node)).to be true
     end
 
@@ -48,16 +67,14 @@ describe Chef::Sugar::Architecture do
   end
 
   describe '#sparc?' do
-    it 'returns true when the system is SPARC' do
+    it 'returns true when the system is SPARC sun4u' do
       node = { 'kernel' => { 'machine' => 'sun4u' } }
       expect(described_class.sparc?(node)).to be true
     end
 
-    _64_bit_machines.each do |arch|
-      it "returns false when the system is #{arch}" do
-        node = { 'kernel' => { 'machine' => arch } }
-        expect(described_class.sparc?(node)).to be false
-      end
+    it 'returns true when the system is SPARC sun4v' do
+      node = { 'kernel' => { 'machine' => 'sun4v' } }
+      expect(described_class.sparc?(node)).to be true
     end
   end
 

--- a/spec/unit/chef/sugar/architecture_spec.rb
+++ b/spec/unit/chef/sugar/architecture_spec.rb
@@ -4,6 +4,7 @@ describe Chef::Sugar::Architecture do
   it_behaves_like 'a chef sugar'
 
   _64_bit_machines = %w(amd64 x86_64 ppc64 ppc64le s390x ia64 sparc64 aarch64 arch64 arm64 sun4u sun4v)
+  _intel_machines = %w(i86pc i386 x86_64 amd64 i686)
 
   describe '#_64_bit?' do
     _64_bit_machines.each do |arch|
@@ -48,19 +49,14 @@ describe Chef::Sugar::Architecture do
   end
 
   describe '#intel?' do
-    it 'returns true when the system is Intel' do
-      node = { 'kernel' => { 'machine' => 'i86pc' } }
-      expect(described_class.intel?(node)).to be true
-    end
-
-    it 'returns true when the system is Intel' do
-      node = { 'kernel' => { 'machine' => 'i386' } }
-      expect(described_class.intel?(node)).to be true
-    end
-
-    _64_bit_machines.each do |arch|
-      it "returns false when the system is #{arch}" do
+    _intel_machines.each do |arch|
+      it "returns true when the system is #{arch}" do
         node = { 'kernel' => { 'machine' => arch } }
+        expect(described_class.intel?(node)).to be true
+      end
+
+      it 'returns false when the system is non Intel' do
+        node = { 'kernel' => { 'machine' => 'sun4u' } }
         expect(described_class.intel?(node)).to be false
       end
     end


### PR DESCRIPTION
Adds sun4v and sun4u to 64bit arch list, since any OS that can runs on those that can use chef-sugar will be 64bit. (not guaranteed - I'm sure there could be an extreme edge case, but highly unlikely and very unsupportable).

Breaks out i386? - this should be Intel specific.

Add i386 arch to intel? - this is a valid option. (Verified vs fauxhai data)

Also added tests to cover as many edge cases as possible.