### PR TITLE
Fix Chef 12.1.0 Warnings for chef_gem compile time install

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,9 +19,15 @@
 
 gem_version = run_context.cookbook_collection[cookbook_name].metadata.version
 
-chef_gem('chef-sugar') do
-  version gem_version
-  action  :nothing
-end.run_action(:install)
+if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
+  chef_gem 'chef-sugar' do
+    version gem_version
+  end
+else
+  chef_gem 'chef-sugar' do
+    version gem_version
+    action :nothing
+  end.run_action(:install)
+end
 
 require 'chef/sugar'


### PR DESCRIPTION
Resolves warnings in Chef 12.1.0 when installing the `chef-sugar` gem.  Should be backwards compatible.  Tested on chef `12.1.0` and chef `11.0.0`

Not sure if the `action :nothing` really needs to be removed... I believe that it does have to be removed or set to `:install` iff the `run_action(:install)` is removed.  Removing it seemed to be the future compatible option