### PR TITLE
Fix default behavior to include chef-sugar at compile time.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ gem_version = run_context.cookbook_collection[cookbook_name].metadata.version
 if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
   chef_gem 'chef-sugar' do
     version gem_version
+    compile_time true
   end
 else
   chef_gem 'chef-sugar' do


### PR DESCRIPTION
This is related to changes in #101.

Am I going crazy or should this be in there? 