### PR TITLE
Fixes the redhat_enterprise_linux? helper from failing.

### DIFF
--- a/lib/chef/sugar/platform.rb
+++ b/lib/chef/sugar/platform.rb
@@ -167,7 +167,7 @@ class Chef
       # @return [Boolean]
       #
       def redhat_enterprise_linux?(node)
-        node['platform'] == 'enterprise'
+        node['platform'] == 'redhat'
       end
       alias_method :redhat_enterprise?, :redhat_enterprise_linux?
 

--- a/spec/unit/chef/sugar/platform_spec.rb
+++ b/spec/unit/chef/sugar/platform_spec.rb
@@ -77,12 +77,12 @@ describe Chef::Sugar::Platform do
 
   describe '#redhat_enterprise_linux?' do
     it 'returns true when the platform is redhat enterprise linux' do
-      node = { 'platform' => 'enterprise' }
+      node = { 'platform' => 'redhat' }
       expect(described_class.redhat_enterprise_linux?(node)).to be true
     end
 
     it 'returns false when the platform is not redhat enterprise linux' do
-      node = { 'platform' => 'windows' }
+      node = { 'platform' => 'enterprise' }
       expect(described_class.redhat_enterprise_linux?(node)).to be false
     end
   end


### PR DESCRIPTION
The platform for RHEL systems is 'redhat' and not 'enterprise'.