### PR TITLE
Adding support for first round of Cisco devices

### DIFF
--- a/lib/chef/sugar/platform.rb
+++ b/lib/chef/sugar/platform.rb
@@ -248,6 +248,28 @@ class Chef
       def raspbian?(node)
         node['platform'] == 'raspbian'
       end
+
+      #
+      # Determine if the current node is a Cisco nexus device
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def nexus?(node)
+        node['platform'] == 'nexus'
+      end
+
+      #
+      # Determine if the current node is a Cisco IOS-XR device
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def ios_xr?(node)
+        node['platform'] == 'ios_xr'
+      end
     end
 
     module DSL

--- a/lib/chef/sugar/platform_family.rb
+++ b/lib/chef/sugar/platform_family.rb
@@ -146,6 +146,17 @@ class Chef
       end
 
       #
+      # Determine if the current node is a member of the wrlinux family.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def wrlinux?(node)
+        node['platform_family'] == 'wrlinux'
+      end
+
+      #
       # Determine if the current system is a linux derivative
       #
       # @param [Chef::Node] node
@@ -161,6 +172,7 @@ class Chef
           rhel
           slackware
           suse
+          wrlinux
         ).include?(node['platform_family'])
       end
     end

--- a/spec/unit/chef/sugar/platform_family_spec.rb
+++ b/spec/unit/chef/sugar/platform_family_spec.rb
@@ -135,6 +135,18 @@ describe Chef::Sugar::PlatformFamily do
     end
   end
 
+  describe '#wrlinux?' do
+    it 'returns true when the platform_family is wrlinux' do
+      node = { 'platform_family' => 'wrlinux' }
+      expect(described_class.wrlinux?(node)).to be true
+    end
+
+    it 'returns false when the platform_family is not wrlinux' do
+      node = { 'platform_family' => 'debian' }
+      expect(described_class.wrlinux?(node)).to be false
+    end
+  end
+
   describe '#linux?' do
     it 'returns true when the platform_family is Debian' do
       node = { 'platform_family' => 'debian' }
@@ -143,6 +155,11 @@ describe Chef::Sugar::PlatformFamily do
 
     it 'returns true when the platform_family is RedHat' do
       node = { 'platform_family' => 'rhel' }
+      expect(described_class.linux?(node)).to be true
+    end
+
+    it 'returns true when the platform_family is wrlinux' do
+      node = { 'platform_family' => 'wrlinux' }
       expect(described_class.linux?(node)).to be true
     end
 

--- a/spec/unit/chef/sugar/platform_spec.rb
+++ b/spec/unit/chef/sugar/platform_spec.rb
@@ -141,9 +141,33 @@ describe Chef::Sugar::Platform do
       expect(described_class.raspbian?(node)).to be true
     end
 
-    it 'returns false when the platform is not omnios' do
+    it 'returns false when the platform is not raspbian' do
       node = { 'platform' => 'windows' }
       expect(described_class.raspbian?(node)).to be false
+    end
+  end
+
+  describe '#nexus' do
+    it 'returns true when the platform is nexus' do
+      node = { 'platform' => 'nexus' }
+      expect(described_class.nexus?(node)).to be true
+    end
+
+    it 'returns false when the platform is not nexus' do
+      node = { 'platform' => 'windows' }
+      expect(described_class.nexus?(node)).to be false
+    end
+  end
+
+  describe '#ios_xr' do
+    it 'returns true when the platform is ios_xr' do
+      node = { 'platform' => 'ios_xr' }
+      expect(described_class.ios_xr?(node)).to be true
+    end
+
+    it 'returns false when the platform is not ios_xr' do
+      node = { 'platform' => 'windows' }
+      expect(described_class.ios_xr?(node)).to be false
     end
   end
 


### PR DESCRIPTION
Chef Client support for Cisco devices is forthcoming, and adding chef-sugar
helpers will allow the omnibus build configs and logic to remain consistent.
This commit adds support for the known Wind River Linux platform family
and the platforms currently targeted for Chef support.