### PR TITLE
adding platform_version method with satisfies? helper method

### DIFF
--- a/lib/chef/sugar.rb
+++ b/lib/chef/sugar.rb
@@ -23,6 +23,7 @@ class Chef
     require_relative 'sugar/architecture'
     require_relative 'sugar/cloud'
     require_relative 'sugar/constraints'
+    require_relative 'sugar/constraints_dsl'
     require_relative 'sugar/data_bag'
     require_relative 'sugar/docker'
     require_relative 'sugar/filters'

--- a/lib/chef/sugar/constraints.rb
+++ b/lib/chef/sugar/constraints.rb
@@ -71,7 +71,7 @@ class Chef
       # @example Compare a version with constraints
       #   Chef::Sugar::Version('1.2.3').satisfies?('~> 1.3.4', '< 2.0.5')
       #
-      class Version
+      class Version < String
         #
         # Create a new version object.
         #
@@ -79,6 +79,7 @@ class Chef
         #   the version to create
         #
         def initialize(version)
+          super
           @version = Gem::Version.new(version)
         end
 

--- a/lib/chef/sugar/constraints.rb
+++ b/lib/chef/sugar/constraints.rb
@@ -17,34 +17,6 @@
 class Chef
   module Sugar
     module Constraints
-      extend self
-
-      #
-      # Shortcut method for creating a new {Version} object.
-      #
-      # @param [String] version
-      #   the version (as a string) to create
-      #
-      # @return [Chef::Sugar::Constraints::Version]
-      #   the new version object
-      #
-      def version(version)
-        Chef::Sugar::Constraints::Version.new(version)
-      end
-
-      #
-      # Shortcut method for creating a new {Constraint} object.
-      #
-      # @param [String, Array<String>] constraints
-      #   the list of constraints to use
-      #
-      # @return [Chef::Sugar::Constraints::Constraint]
-      #   the new constraint object
-      #
-      def constraint(*constraints)
-        Chef::Sugar::Constraints::Constraint.new(*constraints)
-      end
-
       #
       # This class is a wrapper around a version requirement that adds a nice
       # DSL for comparing constraints:
@@ -129,32 +101,6 @@ class Chef
         def satisfies?(*constraints)
           Gem::Requirement.new(*constraints).satisfied_by?(@version)
         end
-      end
-    end
-
-    module DSL
-      # @see Chef::Sugar::Constraints#version
-      def version(version)
-        Chef::Sugar::Constraints::Version.new(version)
-      end
-
-      # @see Chef::Sugar::Constraints#constraint
-      def constraint(*constraints)
-        Chef::Sugar::Constraints.constraint(*constraints)
-      end
-
-      #
-      # This wrapper/convenience method is only available in the recipe DSL. It
-      # creates a new version object from the {Chef::VERSION}.
-      #
-      # @example Check if Chef 11+
-      #   chef_version.satisfies?('>= 11.0.0')
-      #
-      # @return [Chef::Sugar::Constraints::Version]
-      #   a version object, wrapping the current {Chef::VERSION}
-      #
-      def chef_version
-        version(Chef::VERSION)
       end
     end
   end

--- a/lib/chef/sugar/constraints_dsl.rb
+++ b/lib/chef/sugar/constraints_dsl.rb
@@ -1,0 +1,83 @@
+#
+# Copyright 2013-2015, Seth Vargo <sethvargo@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'constraints'
+
+class Chef
+  module Sugar
+    #
+    # The Constraints DSL methods were broken out into this separate
+    # file to allow projects (such as Omnibus) to consume the
+    # Chef::Sugar::Constraints classes without the DSL methods
+    # stepping on existing methods of the same name.
+    #
+    module Constraints
+      extend self
+
+      #
+      # Shortcut method for creating a new {Version} object.
+      #
+      # @param [String] version
+      #   the version (as a string) to create
+      #
+      # @return [Chef::Sugar::Constraints::Version]
+      #   the new version object
+      #
+      def version(version)
+        Chef::Sugar::Constraints::Version.new(version)
+      end
+
+      #
+      # Shortcut method for creating a new {Constraint} object.
+      #
+      # @param [String, Array<String>] constraints
+      #   the list of constraints to use
+      #
+      # @return [Chef::Sugar::Constraints::Constraint]
+      #   the new constraint object
+      #
+      def constraint(*constraints)
+        Chef::Sugar::Constraints::Constraint.new(*constraints)
+      end
+    end
+
+    module DSL
+      # @see Chef::Sugar::Constraints#version
+      def version(version)
+        Chef::Sugar::Constraints::Version.new(version)
+      end
+
+      # @see Chef::Sugar::Constraints#constraint
+      def constraint(*constraints)
+        Chef::Sugar::Constraints.constraint(*constraints)
+      end
+
+      #
+      # This wrapper/convenience method is only available in the recipe DSL. It
+      # creates a new version object from the {Chef::VERSION}.
+      #
+      # @example Check if Chef 11+
+      #   chef_version.satisfies?('>= 11.0.0')
+      #
+      # @return [Chef::Sugar::Constraints::Version]
+      #   a version object, wrapping the current {Chef::VERSION}
+      #
+      def chef_version
+        version(Chef::VERSION)
+      end
+    end
+  end
+end

--- a/lib/chef/sugar/platform.rb
+++ b/lib/chef/sugar/platform.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require_relative 'constraints'
+
 class Chef
   module Sugar
     module Platform
@@ -277,21 +279,10 @@ class Chef
       #
       # @param [Chef::Node] node
       #
-      # @return [Chef::Sugar::Platform::Version]
+      # @return [Chef::Sugar::Constraints::Version]
       #
       def platform_version(node)
-        Chef::Sugar::Platform::Version.new(node)
-      end
-
-      class Version < String
-        def initialize(node)
-          super node['platform_version']
-          @version = Gem::Version.new(node['platform_version'])
-        end
-
-        def satisfies?(*constraints)
-          Gem::Requirement.new(*constraints).satisfied_by?(@version)
-        end
+        Chef::Sugar::Constraints::Version.new(node['platform_version'])
       end
     end
 

--- a/lib/chef/sugar/platform.rb
+++ b/lib/chef/sugar/platform.rb
@@ -270,6 +270,29 @@ class Chef
       def ios_xr?(node)
         node['platform'] == 'ios_xr'
       end
+
+      #
+      # Return the platform_version for the node. Acts like a String
+      # but also provides a mechanism for checking version constraints.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Chef::Sugar::Platform::Version]
+      #
+      def platform_version(node)
+        Chef::Sugar::Platform::Version.new(node)
+      end
+
+      class Version < String
+        def initialize(node)
+          super node['platform_version']
+          @version = Gem::Version.new(node['platform_version'])
+        end
+
+        def satisfies?(*constraints)
+          Gem::Requirement.new(*constraints).satisfied_by?(@version)
+        end
+      end
     end
 
     module DSL

--- a/spec/unit/chef/sugar/constraints_spec.rb
+++ b/spec/unit/chef/sugar/constraints_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 
 describe Chef::Sugar::Constraints do
-  # it_behaves_like 'a chef sugar'
-
   describe '#version' do
     let(:version) { described_class.version('1.2.3') }
 
     it 'returns a new version object' do
       expect(version).to be_a(Chef::Sugar::Constraints::Version)
+    end
+
+    it 'behaves like a String' do
+      expect(version).to be_a(String)
     end
 
     it 'returns true with the version is satisifed' do

--- a/spec/unit/chef/sugar/platform_spec.rb
+++ b/spec/unit/chef/sugar/platform_spec.rb
@@ -334,6 +334,10 @@ describe Chef::Sugar::Platform::Version do
   let(:platform_version) { described_class.new(node) }
 
   describe '#initialize' do
+    it 'acts like a String' do
+      expect(platform_version).to be_a(String)
+    end
+    
     it 'returns the platform_version when called' do
       expect(platform_version).to eq('1.2.3')
     end

--- a/spec/unit/chef/sugar/platform_spec.rb
+++ b/spec/unit/chef/sugar/platform_spec.rb
@@ -171,6 +171,13 @@ describe Chef::Sugar::Platform do
     end
   end
 
+  describe '#platform_version' do
+    it 'returns the platform version' do
+      node = { 'platform_version' => '1.2.3' }
+      expect(described_class.platform_version(node)).to eq('1.2.3')
+    end
+  end
+
   context 'dynamic matchers' do
     describe '#ubuntu_after_lucid?' do
       it 'returns true when the version is later than 10.04' do
@@ -318,6 +325,26 @@ describe Chef::Sugar::Platform do
         node = { 'platform' => 'solaris2', 'platform_version' => '5.11' }
         expect(described_class.solaris_11?(node)).to be true
       end
+    end
+  end
+end
+
+describe Chef::Sugar::Platform::Version do
+  let(:node)             { { 'platform_version' => '1.2.3' } }
+  let(:platform_version) { described_class.new(node) }
+
+  describe '#initialize' do
+    it 'returns the platform_version when called' do
+      expect(platform_version).to eq('1.2.3')
+    end
+  end
+
+  describe '#satisfies?' do
+    it 'invokes Gem::Requirement to check the constraints and returns the result' do
+      requirement = double('requirement')
+      expect(Gem::Requirement).to receive(:new).with('> 1').and_return(requirement)
+      expect(requirement).to receive(:satisfied_by?).and_return(true)
+      expect(platform_version.satisfies?('> 1')).to be true
     end
   end
 end

--- a/spec/unit/chef/sugar/platform_spec.rb
+++ b/spec/unit/chef/sugar/platform_spec.rb
@@ -328,27 +328,3 @@ describe Chef::Sugar::Platform do
     end
   end
 end
-
-describe Chef::Sugar::Platform::Version do
-  let(:node)             { { 'platform_version' => '1.2.3' } }
-  let(:platform_version) { described_class.new(node) }
-
-  describe '#initialize' do
-    it 'acts like a String' do
-      expect(platform_version).to be_a(String)
-    end
-    
-    it 'returns the platform_version when called' do
-      expect(platform_version).to eq('1.2.3')
-    end
-  end
-
-  describe '#satisfies?' do
-    it 'invokes Gem::Requirement to check the constraints and returns the result' do
-      requirement = double('requirement')
-      expect(Gem::Requirement).to receive(:new).with('> 1').and_return(requirement)
-      expect(requirement).to receive(:satisfied_by?).and_return(true)
-      expect(platform_version.satisfies?('> 1')).to be true
-    end
-  end
-end


### PR DESCRIPTION
See #125 as well as https://github.com/chef/omnibus-software/pull/531#issuecomment-164175616. Added a new `platform_version` method that returns the platform version but also provides a `satisfies?` helper method for checking version constraints.

I'm totally open to a different way of implementing this, but this felt like the simplest way to approach.

Thanks for taking a look, @sethvargo :)