### PR TITLE
use gem command in cookbook metadata

### DIFF
--- a/libraries/chef-sugar.rb
+++ b/libraries/chef-sugar.rb
@@ -1,0 +1,1 @@
+require "chef-sugar" if Gem::Requirement.new(">= 12.10.48").satisfied_by?(Gem::Version.new(Chef::VERSION))

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,5 @@ EOH
 
 require          File.expand_path('../lib/chef/sugar/version', __FILE__)
 version          Chef::Sugar::VERSION
+
+gem "chef-sugar" if Gem::Requirement.new(">= 12.10.48").satisfied_by?(Gem::Version.new(Chef::VERSION))


### PR DESCRIPTION
uses https://github.com/chef/chef-rfc/blob/master/rfc060-metadata-gem-installation.md to install chef-sugar

benefit is that even in the first install the gem will be installed before even library loading is done so that chef-sugar would be more useful outside of just recipe + provider code.
