### PR TITLE
Fixes the systemd? check for pre Linux 2.6.33 kernels

### DIFF
--- a/lib/chef/sugar/init.rb
+++ b/lib/chef/sugar/init.rb
@@ -25,7 +25,8 @@ class Chef
       # @return [Boolean]
       #
       def systemd?(node)
-        IO.read('/proc/1/comm').chomp == 'systemd'
+        file = '/proc/1/comm'
+        File.exist?(file) && IO.read(file).chomp == 'systemd'
       end
 
       #

--- a/spec/unit/chef/sugar/init_spec.rb
+++ b/spec/unit/chef/sugar/init_spec.rb
@@ -22,10 +22,19 @@ describe Chef::Sugar::Init do
         .and_return("systemd")
 
       node = {}
-      expect(described_class.systemd?(node)).to be true 
+      expect(described_class.systemd?(node)).to be true
     end
 
     it 'is false when /proc/1/comm is not systemd' do
+      node = {}
+      expect(described_class.systemd?(node)).to be false
+    end
+
+    it 'is false when /proc/1/comm does not exist' do
+      allow(File).to receive(:exist?)
+        .with("/proc/1/comm")
+        .and_return(false)
+
       node = {}
       expect(described_class.systemd?(node)).to be false
     end


### PR DESCRIPTION
`/proc/<pid>/comm` was introduced in linux 2.6.33. Not 100% but I don't think systemd ever worked on those kernels.

Another way of fixing this is by checking for the kernel version instead of the existence of that file.