### PR TITLE
Require Ruby 2.1 or later

### DIFF
--- a/chef-sugar.gemspec
+++ b/chef-sugar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/sethvargo/chef-sugar'
   spec.license       = 'Apache 2.0'
 
-  spec.required_ruby_version = '>= 1.9'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
1.9 and 2.0 are no longer supported Ruby releases

Signed-off-by: Tim Smith <tsmith@chef.io>