### PR TITLE
Modifies systemd? behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the chef-sugar cookbook and gem.
 
+## v5.0.1 (2019-03-13)
+
+- Modifies the behavior of `systemd?` so that it works equally well on physical/virtual
+machines as well as within containers.
+
 ## v5.0.0 (2018-12-26)
 
 - BREAKING CHANGE: Require Chef 13 or later

--- a/lib/chef/sugar/init.rb
+++ b/lib/chef/sugar/init.rb
@@ -25,7 +25,7 @@ class Chef
       # @return [Boolean]
       #
       def systemd?(node)
-        File.executable?('/bin/systemctl')
+        File.exist?('/bin/systemctl')
       end
 
       #

--- a/lib/chef/sugar/init.rb
+++ b/lib/chef/sugar/init.rb
@@ -25,8 +25,7 @@ class Chef
       # @return [Boolean]
       #
       def systemd?(node)
-        file = '/proc/1/comm'
-        File.exist?(file) && IO.read(file).chomp == 'systemd'
+        File.executable?('/bin/systemctl')
       end
 
       #

--- a/lib/chef/sugar/version.rb
+++ b/lib/chef/sugar/version.rb
@@ -16,6 +16,6 @@
 
 class Chef
   module Sugar
-    VERSION = '5.0.0'
+    VERSION = '5.0.1'
   end
 end

--- a/spec/unit/chef/sugar/init_spec.rb
+++ b/spec/unit/chef/sugar/init_spec.rb
@@ -17,8 +17,8 @@ describe Chef::Sugar::Init do
 
   describe '#systemd?' do
     systemctl_path = '/bin/systemctl'
-    it "is true when #{systemctl_path} exists and is exectuable" do
-      allow(File).to receive(:executable?)
+    it "is true when #{systemctl_path} exists" do
+      allow(File).to receive(:exist?)
         .with(systemctl_path)
         .and_return(true)
 
@@ -26,8 +26,8 @@ describe Chef::Sugar::Init do
       expect(described_class.systemd?(node)).to be true
     end
 
-    it "is false when #{systemctl_path} does not exist and/or is not executable" do
-      allow(File).to receive(:executable?)
+    it "is false when #{systemctl_path} does not exist" do
+      allow(File).to receive(:exist?)
         .with(systemctl_path)
         .and_return(false)
 

--- a/spec/unit/chef/sugar/init_spec.rb
+++ b/spec/unit/chef/sugar/init_spec.rb
@@ -16,23 +16,19 @@ describe Chef::Sugar::Init do
   end
 
   describe '#systemd?' do
-    it 'is true when /proc/1/comm is systemd' do
-      allow(IO).to receive(:read)
-        .with("/proc/1/comm")
-        .and_return("systemd")
+    systemctl_path = '/bin/systemctl'
+    it "is true when #{systemctl_path} exists and is exectuable" do
+      allow(File).to receive(:executable?)
+        .with(systemctl_path)
+        .and_return(true)
 
       node = {}
       expect(described_class.systemd?(node)).to be true
     end
 
-    it 'is false when /proc/1/comm is not systemd' do
-      node = {}
-      expect(described_class.systemd?(node)).to be false
-    end
-
-    it 'is false when /proc/1/comm does not exist' do
-      allow(File).to receive(:exist?)
-        .with("/proc/1/comm")
+    it "is false when #{systemctl_path} does not exist and/or is not executable" do
+      allow(File).to receive(:executable?)
+        .with(systemctl_path)
         .and_return(false)
 
       node = {}


### PR DESCRIPTION
- Checks for the presence and executable-ness of `systemctl`, similar to the pattern used for other supervisors.
- This also help support cases where chef-sugar is used on containers (i.e. for unit testing) where `/proc/1/comm` will not be 'systemd' but the name of the process running in the container (i.e. 'bash' or 'ssh').

Signed-off-by: Ryan Frantz <ryanleefrantz@gmail.com>